### PR TITLE
Idea regarding how to state our minimum required versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Data Wrangler is a code-centric data cleaning tool that is integrated into VS Co
 ## Setting up your environment
 
 1. If you have not already done so, install [Python](https://www.python.org/downloads/).  
-   **IMPORTANT:** Make sure to install Python 3.7 or higher.
+   **IMPORTANT:** Data Wrangler only supports Python version 3.7 or higher.
 2. Install [VS Code](https://code.visualstudio.com/download).
 3. Install the Data Wrangler extension for VS Code from the Visual Studio Marketplace. For additional details on installing extensions, see Extension Marketplace. The Data Wrangler extension is named Data Wrangler and it’s published by Microsoft.
 


### PR DESCRIPTION
Context:
- Python 3.6 is at end-of-life. Python 3.6 also [breaks on vscode-jupyter](https://github.com/microsoft/vscode-jupyter/issues/12954).
- While we automatically try to install pandas and regex, it might be useful to reference the minimum supported versions of both in the README.
- We can also use this format in case we need to add more minimum required versions in the future.